### PR TITLE
[fix] `fromSeed` -> `fromMnemonic`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dogecoin-bip84",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Creates BIP84 keychains for Dogecoin mainnet and testnet",
   "main": "./src/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,10 @@ const { bip32 } = require('bitcoinjs-lib')
     , { NETWORKS } = require('./constants')
 
 function fromMnemonic(mnemonic, password, isTestnet) {
-  BIP84.fromSeed.call(this, mnemonic, password, isTestnet, 3)
+  BIP84.fromMnemonic.call(this, mnemonic, password, isTestnet, 3)
 }
 
-fromMnemonic.prototype = Object.create(BIP84.fromSeed.prototype)
+fromMnemonic.prototype = Object.create(BIP84.fromMnemonic.prototype)
 
 function fromZPrv(zprv) {
   BIP84.fromZPrv.call(this, zprv, false, NETWORKS)


### PR DESCRIPTION
Hi!
You renamed the method `fromSeed` to `fromMnemonic` in bip84 package, but you forgot to update this method in dogecoin-bip84.